### PR TITLE
[FL-1128] Speed up `cups-exporter` restart time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,5 @@ RUN apt-get update && \
 RUN pip install --upgrade pip pipenv
 RUN pipenv install --system
 RUN groupadd -g 10001 app && \
-    useradd -r -u 10001 -g app app && \
-    mkdir /usr/app && chown app:app /usr/app
-WORKDIR /usr/app
-COPY . /usr/app
+    useradd -r -u 10001 -g app app
 USER app
-
-# Add and run python app
-COPY cups_exporter.py .
-ENTRYPOINT ["python", "cups_exporter.py"]
-CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,11 @@ RUN apt-get update && \
 RUN pip install --upgrade pip pipenv
 RUN pipenv install --system
 RUN groupadd -g 10001 app && \
-    useradd -r -u 10001 -g app app
+    useradd -r -u 10001 -g app app && \
+    mkdir /usr/app && chown app:app /usr/app
+WORKDIR /usr/app
+COPY . /usr/app
 USER app
+
+ENTRYPOINT ["python", "cups_exporter.py"]
+CMD []

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker compose build cups-exporter
+
+run:
+	docker compose up --force-recreate cups-exporter

--- a/cups_exporter.py
+++ b/cups_exporter.py
@@ -2,6 +2,7 @@
 """Export CUPS metrics to prometheus
 """
 
+import signal
 import argparse
 import time
 
@@ -144,6 +145,17 @@ class CUPSCollector:
                     1)
 
 
+class SignalHandler:
+    exit = False
+
+    def __init__(self):
+        signal.signal(signal.SIGINT, self.exit_gracefully)
+        signal.signal(signal.SIGTERM, self.exit_gracefully)
+
+    def exit_gracefully(self, signum, frame):
+        self.exit = True
+
+
 if __name__ == '__main__':
     # Start up the server to expose the metrics.
     REGISTRY.register(CUPSCollector(
@@ -151,5 +163,7 @@ if __name__ == '__main__':
         args.cups_port,
         args.cups_user))
     start_http_server(args.listen_port)
-    while True:
+
+    sig_handler = SignalHandler()
+    while not sig_handler.exit:
         time.sleep(1)

--- a/cups_exporter.py
+++ b/cups_exporter.py
@@ -180,7 +180,7 @@ class SignalHandler:
 
 if __name__ == "__main__":
     # Start up the server to expose the metrics.
-    logger.warning(f"Starting CUPS exporter server with args: {args}")
+    logger.info(f"Starting CUPS exporter server with args: {args}")
     REGISTRY.register(
         CUPSCollector(
             args.cups_host,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  cups-exporter:
+    build: .
+    ports:
+      - 9329:9329
+    restart: unless-stopped
+    user: 10001:10001
+    volumes:
+      - .:/usr/app
+    command: python usr/app/cups_exporter.py --cups-port 6631

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,4 @@ services:
       - 9329:9329
     restart: unless-stopped
     user: 10001:10001
-    volumes:
-      - .:/usr/app
-    command: python usr/app/cups_exporter.py --cups-port 6631
+    command: --cups-port 6631


### PR DESCRIPTION
## What

Add a signal handler to the application so that we can shut down gracefully when a `SIGINT` or `SIGTERM` is sent. Currently these are sent and ignored, then after a grace period the process is killed off without warning.

Ran the file through the `black` formatter to tidy things up as well.